### PR TITLE
fix: normalize blank tool inputs and harden alert validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Agent Protocol
 
 **Server:** nws-weather-mcp-server
-**Version:** 0.5.1
+**Version:** 0.5.2
 **Framework:** [@cyanheads/mcp-ts-core](https://www.npmjs.com/package/@cyanheads/mcp-ts-core)
 
 > **Read the framework docs first:** `node_modules/@cyanheads/mcp-ts-core/CLAUDE.md` contains the full API reference — builders, Context, error codes, exports, patterns. This file covers server-specific conventions only.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.2] - 2026-04-14
+
+### Changed
+
+- **Release metadata** — Bumped package, manifest, README badge, and agent-protocol versions to `0.5.2`.
+
+### Fixed
+
+- **Alert filter validation** — Rejected mutually exclusive non-empty `area`, `point`, and `zone` combinations in `nws_search_alerts` before hitting the NWS API, while normalizing blank optional location fields away for form-style clients.
+- **Alert error details** — Surfaced NWS `parameterErrors` messages for alert-query `400` responses so clients receive actionable validation feedback instead of generic `Bad Request` failures.
+- **Observation station ID normalization** — Trimmed `station_id` inputs in `nws_get_observations` and treated blank values as omitted so coordinate lookups still work when form-based clients send empty optional fields.
+
 ## [0.5.1] - 2026-04-14
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # Agent Protocol
 
 **Server:** nws-weather-mcp-server
-**Version:** 0.5.1
+**Version:** 0.5.2
 **Framework:** [@cyanheads/mcp-ts-core](https://www.npmjs.com/package/@cyanheads/mcp-ts-core)
 
 > **Read the framework docs first:** `node_modules/@cyanheads/mcp-ts-core/CLAUDE.md` contains the full API reference — builders, Context, error codes, exports, patterns. This file covers server-specific conventions only.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <div align="center">
 
-[![npm](https://img.shields.io/npm/v/@cyanheads/nws-weather-mcp-server?style=flat-square&logo=npm&logoColor=white)](https://www.npmjs.com/package/@cyanheads/nws-weather-mcp-server) [![Version](https://img.shields.io/badge/Version-0.5.1-blue.svg?style=flat-square)](./CHANGELOG.md) [![Framework](https://img.shields.io/badge/Built%20on-@cyanheads/mcp--ts--core-259?style=flat-square)](https://www.npmjs.com/package/@cyanheads/mcp-ts-core) [![MCP SDK](https://img.shields.io/badge/MCP%20SDK-^1.29.0-green.svg?style=flat-square)](https://modelcontextprotocol.io/) 
+[![npm](https://img.shields.io/npm/v/@cyanheads/nws-weather-mcp-server?style=flat-square&logo=npm&logoColor=white)](https://www.npmjs.com/package/@cyanheads/nws-weather-mcp-server) [![Version](https://img.shields.io/badge/Version-0.5.2-blue.svg?style=flat-square)](./CHANGELOG.md) [![Framework](https://img.shields.io/badge/Built%20on-@cyanheads/mcp--ts--core-259?style=flat-square)](https://www.npmjs.com/package/@cyanheads/mcp-ts-core) [![MCP SDK](https://img.shields.io/badge/MCP%20SDK-^1.29.0-green.svg?style=flat-square)](https://modelcontextprotocol.io/) 
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-orange.svg?style=flat-square)](./LICENSE) [![TypeScript](https://img.shields.io/badge/TypeScript-^6.0.2-3178C6.svg?style=flat-square)](https://www.typescriptlang.org/) [![Bun](https://img.shields.io/badge/Bun-v1.2+-blueviolet.svg?style=flat-square)](https://bun.sh/)
 
@@ -49,7 +49,9 @@ Get the weather forecast for a US location.
 Search active weather alerts with flexible filtering.
 
 - Filter by area (state/territory/marine codes), point (lat,lon), zone, event type, severity, urgency, certainty, or status
+- `area`, `point`, and `zone` are mutually exclusive; specify at most one location filter
 - National search when no filters provided
+- Blank optional location filters are ignored so form-based clients can submit empty fields safely
 - Event matching is case-insensitive and partial, so `"tornado"` matches both watches and warnings
 - `status` defaults to live `Actual` alerts, but can be set to `Exercise`, `System`, `Test`, or `Draft`
 - Results capped at 25 with truncation notice and guidance to narrow filters
@@ -62,6 +64,7 @@ Search active weather alerts with flexible filtering.
 Current measured conditions from a weather station.
 
 - Look up by coordinates (finds nearest station) or station ID directly
+- Blank or whitespace-only `station_id` values are ignored so clients can fall back to coordinates cleanly
 - Coordinate lookups choose the nearest station from the candidates returned by NWS
 - Dual-unit display: F/C, mph/km/h, inHg/hPa, mi/km
 - Observation timestamps use the station's local time zone when available

--- a/bun.lock
+++ b/bun.lock
@@ -5,19 +5,19 @@
     "": {
       "name": "@cyanheads/nws-weather-mcp-server",
       "dependencies": {
-        "@cyanheads/mcp-ts-core": "latest",
-        "@opentelemetry/api": "latest",
-        "pino-pretty": "latest",
+        "@cyanheads/mcp-ts-core": "^0.3.5",
+        "@opentelemetry/api": "^1.9.1",
+        "pino-pretty": "^13.1.3",
       },
       "devDependencies": {
-        "@biomejs/biome": "latest",
-        "@types/node": "latest",
-        "@vitest/coverage-istanbul": "latest",
-        "depcheck": "latest",
-        "ignore": "latest",
-        "tsc-alias": "latest",
-        "typescript": "latest",
-        "vitest": "latest",
+        "@biomejs/biome": "^2.4.12",
+        "@types/node": "^25.6.0",
+        "@vitest/coverage-istanbul": "^4.1.4",
+        "depcheck": "^1.4.7",
+        "ignore": "^7.0.5",
+        "tsc-alias": "^1.8.16",
+        "typescript": "^6.0.2",
+        "vitest": "^4.1.4",
       },
     },
   },
@@ -54,23 +54,23 @@
 
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
 
-    "@biomejs/biome": ["@biomejs/biome@2.4.11", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.11", "@biomejs/cli-darwin-x64": "2.4.11", "@biomejs/cli-linux-arm64": "2.4.11", "@biomejs/cli-linux-arm64-musl": "2.4.11", "@biomejs/cli-linux-x64": "2.4.11", "@biomejs/cli-linux-x64-musl": "2.4.11", "@biomejs/cli-win32-arm64": "2.4.11", "@biomejs/cli-win32-x64": "2.4.11" }, "bin": { "biome": "bin/biome" } }, "sha512-nWxHX8tf3Opb/qRgZpBbsTOqOodkbrkJ7S+JxJAruxOReaDPPmPuLBAGQ8vigyUgo0QBB+oQltNEAvalLcjggA=="],
+    "@biomejs/biome": ["@biomejs/biome@2.4.12", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.12", "@biomejs/cli-darwin-x64": "2.4.12", "@biomejs/cli-linux-arm64": "2.4.12", "@biomejs/cli-linux-arm64-musl": "2.4.12", "@biomejs/cli-linux-x64": "2.4.12", "@biomejs/cli-linux-x64-musl": "2.4.12", "@biomejs/cli-win32-arm64": "2.4.12", "@biomejs/cli-win32-x64": "2.4.12" }, "bin": { "biome": "bin/biome" } }, "sha512-Rro7adQl3NLq/zJCIL98eElXKI8eEiBtoeu5TbXF/U3qbjuSc7Jb5rjUbeHHcquDWeSf3HnGP7XI5qGrlRk/pA=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.11", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wOt+ed+L2dgZanWyL6i29qlXMc088N11optzpo10peayObBaAshbTcxKUchzEMp9QSY8rh5h6VfAFE3WTS1rqg=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-BnMU4Pc3ciEVteVpZ0BK33MLr7X57F5w1dwDLDn+/iy/yTrA4Q/N2yftidFtsA4vrDh0FMXDpacNV/Tl3fbmng=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.11", "", { "os": "darwin", "cpu": "x64" }, "sha512-gZ6zR8XmZlExfi/Pz/PffmdpWOQ8Qhy7oBztgkR8/ylSRyLwfRPSadmiVCV8WQ8PoJ2MWUy2fgID9zmtgUUJmw=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-x9uJ0bI1rJsWICp3VH8w/5PnAVD3A7SqzDpbrfoUQX1QyWrK5jSU4fRLo/wSgGeplCivbxBRKmt5Xq4/nWvq8A=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.11", "", { "os": "linux", "cpu": "arm64" }, "sha512-avdJaEElXrKceK0va9FkJ4P5ci3N01TGkc6ni3P8l3BElqbOz42Wg2IyX3gbh0ZLEd4HVKEIrmuVu/AMuSeFFA=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-tOwuCuZZtKi1jVzbk/5nXmIsziOB6yqN8c9r9QM0EJYPU6DpQWf11uBOSCfFKKM4H3d9ZoarvlgMfbcuD051Pw=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.11", "", { "os": "linux", "cpu": "arm64" }, "sha512-+Sbo1OAmlegtdwqFE8iOxFIWLh1B3OEgsuZfBpyyN/kWuqZ8dx9ZEes6zVnDMo+zRHF2wLynRVhoQmV7ohxl2Q=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-FhfpkAAlKL6kwvcVap0Hgp4AhZmtd3YImg0kK1jd7C/aSoh4SfsB2f++yG1rU0lr8Y5MCFJrcSkmssiL9Xnnig=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.11", "", { "os": "linux", "cpu": "x64" }, "sha512-TagWV0iomp5LnEnxWFg4nQO+e52Fow349vaX0Q/PIcX6Zhk4GGBgp3qqZ8PVkpC+cuehRctMf3+6+FgQ8jCEFQ=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.12", "", { "os": "linux", "cpu": "x64" }, "sha512-8pFeAnLU9QdW9jCIslB/v82bI0lhBmz2ZAKc8pVMFPO0t0wAHsoEkrUQUbMkIorTRIjbqyNZHA3lEXavsPWYSw=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.11", "", { "os": "linux", "cpu": "x64" }, "sha512-bexd2IklK7ZgPhrz6jXzpIL6dEAH9MlJU1xGTrypx+FICxrXUp4CqtwfiuoDKse+UlgAlWtzML3jrMqeEAHEhA=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.12", "", { "os": "linux", "cpu": "x64" }, "sha512-dwTIgZrGutzhkQCuvHynCkyW6hJxUuyZqKKO0YNfaS2GUoRO+tOvxXZqZB6SkWAOdfZTzwaw8IEdUnIkHKHoew=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.11", "", { "os": "win32", "cpu": "arm64" }, "sha512-RJhaTnY8byzxDt4bDVb7AFPHkPcjOPK3xBip4ZRTrN3TEfyhjLRm3r3mqknqydgVTB74XG8l4jMLwEACEeihVg=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-B0DLnx0vA9ya/3v7XyCaP+/lCpnbWbMOfUFFve+xb5OxyYvdHaS55YsSddr228Y+JAFk58agCuZTsqNiw2a6ig=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.11", "", { "os": "win32", "cpu": "x64" }, "sha512-A8D3JM/00C2KQgUV3oj8Ba15EHEYwebAGCy5Sf9GAjr5Y3+kJIYOiESoqRDeuRZueuMdCsbLZIUqmPhpYXJE9A=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.12", "", { "os": "win32", "cpu": "x64" }, "sha512-yMckRzTyZ83hkk8iDFWswqSdU8tvZxspJKnYNh7JZr/zhZNOlzH13k4ecboU6MurKExCe2HUkH75pGI/O2JwGA=="],
 
     "@cyanheads/mcp-ts-core": ["@cyanheads/mcp-ts-core@0.3.5", "", { "dependencies": { "@hono/mcp": "^0.2.5", "@hono/node-server": "^1.19.13", "@modelcontextprotocol/ext-apps": "^1.5.0", "@modelcontextprotocol/sdk": "^1.29.0", "@opentelemetry/api": "^1.9.1", "dotenv": "^17.4.1", "hono": "^4.12.12", "jose": "^6.2.2", "pino": "^10.3.1", "zod": "^4.3.6" }, "peerDependencies": { "@hono/otel": "^1.1.1", "@opentelemetry/exporter-metrics-otlp-http": "^0.214.0", "@opentelemetry/exporter-trace-otlp-http": "^0.214.0", "@opentelemetry/instrumentation-http": "^0.214.0", "@opentelemetry/instrumentation-pino": "^0.60.0", "@opentelemetry/resources": "^2.6.0", "@opentelemetry/sdk-metrics": "^2.6.0", "@opentelemetry/sdk-node": "^0.214.0", "@opentelemetry/sdk-trace-node": "^2.6.0", "@opentelemetry/semantic-conventions": "^1.40.0", "@supabase/supabase-js": "^2.99.3", "chrono-node": "^2.9.0", "diff": "^8.0.4", "fast-xml-parser": "latest", "js-yaml": "^4.1.0", "node-cron": "^4.2.1", "openai": "^6.32.0", "papaparse": "^5.5.3", "partial-json": "^0.1.7", "pdf-lib": "^1.17.1", "sanitize-html": "^2.17.2", "unpdf": "^1.4.0", "validator": "^13.15.26" }, "optionalPeers": ["@hono/otel", "@opentelemetry/exporter-metrics-otlp-http", "@opentelemetry/exporter-trace-otlp-http", "@opentelemetry/instrumentation-http", "@opentelemetry/instrumentation-pino", "@opentelemetry/resources", "@opentelemetry/sdk-metrics", "@opentelemetry/sdk-node", "@opentelemetry/sdk-trace-node", "@opentelemetry/semantic-conventions", "@supabase/supabase-js", "chrono-node", "diff", "fast-xml-parser", "js-yaml", "node-cron", "openai", "papaparse", "partial-json", "pdf-lib", "sanitize-html", "unpdf", "validator"], "bin": { "mcp-ts-core": "dist/cli/init.js" } }, "sha512-jfiOtMV0vOv5DZfG6ASxQojIA0GryArgnSYYtS9A6j2KQzsAhhrsN00+dW7d1SNxKTvsbzkJxAveYsMPtJQ21w=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cyanheads/nws-weather-mcp-server",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Real-time US weather data via the National Weather Service API. Forecasts, alerts, and observations with zero auth.",
   "type": "module",
   "main": "dist/index.js",
@@ -70,7 +70,7 @@
     "pino-pretty": "^13.1.3"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.4.11",
+    "@biomejs/biome": "^2.4.12",
     "@types/node": "^25.6.0",
     "@vitest/coverage-istanbul": "^4.1.4",
     "depcheck": "^1.4.7",

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/cyanheads/nws-weather-mcp-server",
     "source": "github"
   },
-  "version": "0.5.1",
+  "version": "0.5.2",
   "remotes": [
     {
       "type": "streamable-http",
@@ -19,7 +19,7 @@
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@cyanheads/nws-weather-mcp-server",
       "runtimeHint": "bun",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "packageArguments": [
         { "type": "positional", "value": "run" },
         { "type": "positional", "value": "start:stdio" }
@@ -49,7 +49,7 @@
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@cyanheads/nws-weather-mcp-server",
       "runtimeHint": "bun",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "packageArguments": [
         { "type": "positional", "value": "run" },
         { "type": "positional", "value": "start:http" }

--- a/src/mcp-server/tools/definitions/get-observations.tool.ts
+++ b/src/mcp-server/tools/definitions/get-observations.tool.ts
@@ -54,6 +54,13 @@ function formatWind(speed: number | null, direction: number | null, gust: number
   return result;
 }
 
+/** Trim optional station IDs and treat blank values as omitted. */
+function normalizeStationId(stationId: string | undefined): string | undefined {
+  if (stationId == null) return;
+  const normalized = stationId.trim();
+  return normalized.length > 0 ? normalized : undefined;
+}
+
 export const getObservationsTool = tool('nws_get_observations', {
   description:
     'Get current weather observations (actual measured conditions). Accepts coordinates (resolves nearest station automatically) or a station ID directly (e.g., "KSEA").',
@@ -111,7 +118,9 @@ export const getObservationsTool = tool('nws_get_observations', {
   }),
 
   async handler(input, ctx) {
-    if (!input.station_id && (input.latitude == null || input.longitude == null)) {
+    const normalizedStationId = normalizeStationId(input.station_id);
+
+    if (!normalizedStationId && (input.latitude == null || input.longitude == null)) {
       throw invalidParams('Provide either station_id or both latitude and longitude.');
     }
 
@@ -119,7 +128,7 @@ export const getObservationsTool = tool('nws_get_observations', {
       {
         latitude: input.latitude,
         longitude: input.longitude,
-        stationId: input.station_id,
+        stationId: normalizedStationId,
       },
       ctx,
     );

--- a/src/mcp-server/tools/definitions/search-alerts.tool.ts
+++ b/src/mcp-server/tools/definitions/search-alerts.tool.ts
@@ -9,6 +9,7 @@ import { getNwsService } from '@/services/nws/nws-service.js';
 import { formatTimestamp } from '../format-utils.js';
 
 const MAX_ALERTS = 25;
+const LOCATION_FILTER_FIELDS = ['area', 'point', 'zone'] as const;
 
 /** Valid area codes: US states, DC, territories, and marine areas. */
 const VALID_AREA_CODES = new Set([
@@ -109,53 +110,85 @@ function describeFilters(input: Record<string, unknown>): string {
   return parts.length > 0 ? parts.join(', ') : 'national (no filters)';
 }
 
+/** Trim optional string filters and treat blank values as omitted. */
+function normalizeOptionalFilter(value: string | undefined): string | undefined {
+  if (value == null) return;
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+/** Normalize location filters and reject combinations the NWS API treats as incompatible. */
+function normalizeSearchAlertsInput(input: SearchAlertsInput): SearchAlertsInput {
+  const normalized = {
+    ...input,
+    area: normalizeOptionalFilter(input.area)?.toUpperCase(),
+    point: normalizeOptionalFilter(input.point),
+    zone: normalizeOptionalFilter(input.zone),
+  };
+
+  const activeLocationFilters = LOCATION_FILTER_FIELDS.filter((fieldName) => normalized[fieldName]);
+  if (activeLocationFilters.length > 1) {
+    throw invalidParams(
+      'area, point, and zone are mutually exclusive. Specify at most one location filter.',
+    );
+  }
+
+  return normalized;
+}
+
+const searchAlertsInputSchema = z.object({
+  area: z
+    .string()
+    .optional()
+    .describe(
+      'US state/territory code (e.g., "WA", "OK", "PR") or marine area code (e.g., "GM"). Mutually exclusive with point and zone.',
+    ),
+  point: z
+    .string()
+    .optional()
+    .describe(
+      'Coordinates as "lat,lon" (e.g., "47.6,-122.3"). Returns alerts whose geometry contains this point. Mutually exclusive with area and zone.',
+    ),
+  zone: z
+    .string()
+    .optional()
+    .describe(
+      'NWS forecast zone (e.g., "WAZ558") or county zone (e.g., "WAC033"). Mutually exclusive with area and point.',
+    ),
+  event: z
+    .array(z.string())
+    .optional()
+    .describe(
+      'Filter to specific event types (e.g., ["Tornado Warning"]). Matches are case-insensitive and partial, so "tornado" matches both "Tornado Warning" and "Tornado Watch". Use nws_list_alert_types to discover valid names.',
+    ),
+  severity: z
+    .array(z.enum(['Extreme', 'Severe', 'Moderate', 'Minor', 'Unknown']))
+    .optional()
+    .describe('Filter by severity level.'),
+  urgency: z
+    .array(z.enum(['Immediate', 'Expected', 'Future', 'Past']))
+    .optional()
+    .describe('Filter by urgency level.'),
+  certainty: z
+    .array(z.enum(['Observed', 'Likely', 'Possible', 'Unlikely', 'Unknown']))
+    .optional()
+    .describe('Filter by certainty level.'),
+  status: z
+    .enum(['Actual', 'Exercise', 'System', 'Test', 'Draft'])
+    .default('Actual')
+    .describe(
+      'Alert status filter. Default "Actual". Use a different value only when you specifically need non-live alerts.',
+    ),
+});
+
+type SearchAlertsInput = z.infer<typeof searchAlertsInputSchema>;
+
 export const searchAlertsTool = tool('nws_search_alerts', {
   description:
-    'Search active weather alerts (watches, warnings, advisories) across the US. Filter by state, coordinates, zone, event type, severity, urgency, or certainty. Omit all filters for a national search.',
+    'Search active weather alerts (watches, warnings, advisories) across the US. Filter by state, coordinates, zone, event type, severity, urgency, or certainty. area, point, and zone are mutually exclusive. Omit all filters for a national search.',
   annotations: { readOnlyHint: true },
 
-  input: z.object({
-    area: z
-      .string()
-      .optional()
-      .describe(
-        'US state/territory code (e.g., "WA", "OK", "PR") or marine area code (e.g., "GM").',
-      ),
-    point: z
-      .string()
-      .optional()
-      .describe(
-        'Coordinates as "lat,lon" (e.g., "47.6,-122.3"). Returns alerts whose geometry contains this point.',
-      ),
-    zone: z
-      .string()
-      .optional()
-      .describe('NWS forecast zone (e.g., "WAZ558") or county zone (e.g., "WAC033").'),
-    event: z
-      .array(z.string())
-      .optional()
-      .describe(
-        'Filter to specific event types (e.g., ["Tornado Warning"]). Matches are case-insensitive and partial, so "tornado" matches both "Tornado Warning" and "Tornado Watch". Use nws_list_alert_types to discover valid names.',
-      ),
-    severity: z
-      .array(z.enum(['Extreme', 'Severe', 'Moderate', 'Minor', 'Unknown']))
-      .optional()
-      .describe('Filter by severity level.'),
-    urgency: z
-      .array(z.enum(['Immediate', 'Expected', 'Future', 'Past']))
-      .optional()
-      .describe('Filter by urgency level.'),
-    certainty: z
-      .array(z.enum(['Observed', 'Likely', 'Possible', 'Unlikely', 'Unknown']))
-      .optional()
-      .describe('Filter by certainty level.'),
-    status: z
-      .enum(['Actual', 'Exercise', 'System', 'Test', 'Draft'])
-      .default('Actual')
-      .describe(
-        'Alert status filter. Default "Actual". Use a different value only when you specifically need non-live alerts.',
-      ),
-  }),
+  input: searchAlertsInputSchema,
 
   output: z.object({
     count: z.number().describe('Total number of matching alerts'),
@@ -183,19 +216,20 @@ export const searchAlertsTool = tool('nws_search_alerts', {
   }),
 
   async handler(input, ctx) {
+    const normalizedInput = normalizeSearchAlertsInput(input);
+
     // Normalize and validate area code — the NWS API is case-sensitive (lowercase → 400)
-    if (input.area) {
-      input.area = input.area.toUpperCase();
-      if (!VALID_AREA_CODES.has(input.area)) {
+    if (normalizedInput.area) {
+      if (!VALID_AREA_CODES.has(normalizedInput.area)) {
         throw invalidParams(
-          `Invalid area code "${input.area}". Use a 2-letter US state/territory code (e.g., "WA", "OK", "PR") or marine area code (e.g., "GM").`,
+          `Invalid area code "${normalizedInput.area}". Use a 2-letter US state/territory code (e.g., "WA", "OK", "PR") or marine area code (e.g., "GM").`,
         );
       }
     }
 
     // Validate point format before hitting the API
-    if (input.point) {
-      const [lat, lon, ...rest] = input.point.split(',').map(Number);
+    if (normalizedInput.point) {
+      const [lat, lon, ...rest] = normalizedInput.point.split(',').map(Number);
       if (
         rest.length > 0 ||
         lat == null ||
@@ -208,15 +242,15 @@ export const searchAlertsTool = tool('nws_search_alerts', {
         lon > 180
       ) {
         throw invalidParams(
-          `Invalid point "${input.point}". Provide "lat,lon" with latitude -90 to 90 and longitude -180 to 180 (e.g., "47.6,-122.3").`,
+          `Invalid point "${normalizedInput.point}". Provide "lat,lon" with latitude -90 to 90 and longitude -180 to 180 (e.g., "47.6,-122.3").`,
         );
       }
     }
 
-    const result = await getNwsService().searchAlerts(input, ctx);
+    const result = await getNwsService().searchAlerts(normalizedInput, ctx);
     const total = result.alerts.length;
     const capped = result.alerts.slice(0, MAX_ALERTS);
-    const filters = describeFilters(input);
+    const filters = describeFilters(normalizedInput);
 
     ctx.log.info('Alerts search completed', { total, shown: capped.length, filters });
 

--- a/src/services/nws/nws-service.ts
+++ b/src/services/nws/nws-service.ts
@@ -57,12 +57,39 @@ const POINTS_NOT_FOUND =
 
 type NotFoundFactory = (message: string) => Error;
 
+/** Return a cleaned message when an NWS field contains useful text. */
+function normalizeNwsMessage(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
 /** Try to extract a detail message from an NWS error response body. */
 function parseNwsErrorDetail(text: string): string | null {
   try {
     const body = JSON.parse(text) as Record<string, unknown>;
-    if (typeof body.detail === 'string') return body.detail;
-    if (typeof body.title === 'string') return body.title;
+    const parameterErrors = Array.isArray(body.parameterErrors)
+      ? [
+          ...new Set(
+            body.parameterErrors
+              .map((error) =>
+                error && typeof error === 'object'
+                  ? normalizeNwsMessage((error as Record<string, unknown>).message)
+                  : null,
+              )
+              .filter((message): message is string => message != null),
+          ),
+        ]
+      : [];
+    if (parameterErrors.length > 0) return parameterErrors.join('; ');
+
+    const detail = normalizeNwsMessage(body.detail);
+    if (detail && detail !== 'Bad Request') return detail;
+
+    const title = normalizeNwsMessage(body.title);
+    if (title) return title;
+
+    if (detail) return detail;
   } catch {
     /* not JSON — ignore */
   }

--- a/tests/services/nws/nws-service.test.ts
+++ b/tests/services/nws/nws-service.test.ts
@@ -162,6 +162,35 @@ describe('NwsService', () => {
       await expect(result).rejects.toThrow('Invalid alert query');
     });
 
+    it('maps upstream parameterErrors to actionable validation errors', async () => {
+      mockFetch.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            correlationId: '5ac24233',
+            parameterErrors: [
+              {
+                parameter: 'query.area',
+                message: 'parameters may not be used together: area, point',
+              },
+            ],
+            title: 'Bad Request',
+            detail: 'Bad Request',
+            status: 400,
+          }),
+          {
+            status: 400,
+            headers: { 'Content-Type': 'application/problem+json' },
+          },
+        ),
+      );
+
+      const ctx = createMockContext({ tenantId: 'test' });
+      const result = service.getNwsService().searchAlerts({}, ctx);
+
+      await expect(result).rejects.toMatchObject({ code: JsonRpcErrorCode.ValidationError });
+      await expect(result).rejects.toThrow('parameters may not be used together: area, point');
+    });
+
     it('maps title-only upstream 400 responses to validation errors', async () => {
       mockFetch.mockResolvedValueOnce(jsonResponse({ title: 'Bad Request' }, 400));
 

--- a/tests/tools/get-observations.tool.test.ts
+++ b/tests/tools/get-observations.tool.test.ts
@@ -71,6 +71,19 @@ describe('nws_get_observations', () => {
     expect(result.cloudLayers[0].amount).toBe('BKN');
   });
 
+  it('trims station_id before calling the service', async () => {
+    mockGetObservation.mockResolvedValueOnce(observationResult);
+
+    const ctx = createMockContext({ tenantId: 'test' });
+    const input = getObservationsTool.input.parse({ station_id: ' KSEA ' });
+    await getObservationsTool.handler(input, ctx);
+
+    expect(mockGetObservation).toHaveBeenCalledWith(
+      expect.objectContaining({ stationId: 'KSEA' }),
+      ctx,
+    );
+  });
+
   it('returns observation data by coordinates', async () => {
     mockGetObservation.mockResolvedValueOnce(observationResult);
 
@@ -85,9 +98,41 @@ describe('nws_get_observations', () => {
     );
   });
 
+  it('ignores blank station_id when coordinates are provided', async () => {
+    mockGetObservation.mockResolvedValueOnce(observationResult);
+
+    const ctx = createMockContext({ tenantId: 'test' });
+    const input = getObservationsTool.input.parse({
+      station_id: '   ',
+      latitude: 47.6,
+      longitude: -122.3,
+    });
+    await getObservationsTool.handler(input, ctx);
+
+    expect(mockGetObservation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stationId: undefined,
+        latitude: 47.6,
+        longitude: -122.3,
+      }),
+      ctx,
+    );
+  });
+
   it('throws when neither station_id nor coordinates provided', async () => {
     const ctx = createMockContext({ tenantId: 'test' });
     const input = getObservationsTool.input.parse({});
+    const result = getObservationsTool.handler(input, ctx);
+
+    await expect(result).rejects.toMatchObject({ code: JsonRpcErrorCode.InvalidParams });
+    await expect(result).rejects.toThrow(
+      'Provide either station_id or both latitude and longitude',
+    );
+  });
+
+  it('treats whitespace-only station_id as omitted when coordinates are missing', async () => {
+    const ctx = createMockContext({ tenantId: 'test' });
+    const input = getObservationsTool.input.parse({ station_id: '   ' });
     const result = getObservationsTool.handler(input, ctx);
 
     await expect(result).rejects.toMatchObject({ code: JsonRpcErrorCode.InvalidParams });

--- a/tests/tools/search-alerts.tool.test.ts
+++ b/tests/tools/search-alerts.tool.test.ts
@@ -92,6 +92,50 @@ describe('nws_search_alerts', () => {
     await expect(result).rejects.toThrow('Invalid area code');
   });
 
+  it('normalizes empty-string location filters away before calling the service', async () => {
+    mockSearchAlerts.mockResolvedValueOnce({ alerts: [] });
+
+    const ctx = createMockContext({ tenantId: 'test' });
+    const input = searchAlertsTool.input.parse({ area: '', point: '', zone: '' });
+    const result = await searchAlertsTool.handler(input, ctx);
+
+    expect(result.filters).toBe('national (no filters)');
+    expect(mockSearchAlerts).toHaveBeenCalledWith(
+      expect.objectContaining({
+        area: undefined,
+        point: undefined,
+        zone: undefined,
+      }),
+      ctx,
+    );
+  });
+
+  it('rejects mutually exclusive area and point filters before calling the service', async () => {
+    const ctx = createMockContext({ tenantId: 'test' });
+    const input = searchAlertsTool.input.parse({ area: 'TX', point: '32.7767,-96.7970' });
+    const result = searchAlertsTool.handler(input, ctx);
+
+    await expect(result).rejects.toMatchObject({ code: JsonRpcErrorCode.InvalidParams });
+    await expect(result).rejects.toThrow('area, point, and zone are mutually exclusive');
+    expect(mockSearchAlerts).not.toHaveBeenCalled();
+  });
+
+  it('ignores whitespace-only location filters when another real filter is present', async () => {
+    mockSearchAlerts.mockResolvedValueOnce({ alerts: [] });
+
+    const ctx = createMockContext({ tenantId: 'test' });
+    const input = searchAlertsTool.input.parse({ area: 'TX', zone: '   ' });
+    await searchAlertsTool.handler(input, ctx);
+
+    expect(mockSearchAlerts).toHaveBeenCalledWith(
+      expect.objectContaining({
+        area: 'TX',
+        zone: undefined,
+      }),
+      ctx,
+    );
+  });
+
   it('passes all filter params to service', async () => {
     mockSearchAlerts.mockResolvedValueOnce({ alerts: [] });
 
@@ -111,6 +155,21 @@ describe('nws_search_alerts', () => {
         urgency: ['Immediate'],
         event: ['tornado'],
         status: 'Actual',
+      }),
+      ctx,
+    );
+  });
+
+  it('trims and normalizes area before passing filters to the service', async () => {
+    mockSearchAlerts.mockResolvedValueOnce({ alerts: [] });
+
+    const ctx = createMockContext({ tenantId: 'test' });
+    const input = searchAlertsTool.input.parse({ area: ' wa ' });
+    await searchAlertsTool.handler(input, ctx);
+
+    expect(mockSearchAlerts).toHaveBeenCalledWith(
+      expect.objectContaining({
+        area: 'WA',
       }),
       ctx,
     );


### PR DESCRIPTION
## Summary

- reject mutually-exclusive non-empty `area` / `point` / `zone` alert filters before calling NWS
- normalize blank optional alert filters and observation `station_id` inputs away so form-based clients can submit empty fields safely
- surface NWS `parameterErrors` messages for alert-query `400` responses
- bump release metadata and docs to `0.5.2`

## Testing

- `bun run test`
- `bun run devcheck`

Closes #4